### PR TITLE
Don’t remove link underlines

### DIFF
--- a/source/assets/stylesheets/base/_typography.scss
+++ b/source/assets/stylesheets/base/_typography.scss
@@ -59,12 +59,12 @@ p {
 
 a {
   color: $base-link-color;
-  text-decoration: none;
   transition: color 0.1s linear;
 
   &:active,
   &:hover {
     color: $hover-link-color;
+    text-decoration: none;
   }
 
   &:focus {


### PR DESCRIPTION
But do remove them on `:hover`.